### PR TITLE
Fix crash when reaping oldest entry, also fixed record entry never got expired. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ pcache is an improved version of the cache described in http://duomark.com/erlan
 Usage
 -----
 The cache server is designed to memoize a specific Module:Fun. The key in
-a cache is the Argument passed in to Module:Fun/1.
+a cache is the Argument passed to Module:Fun/1.
 
 Start a cache:
+
         CacheName = my_cache,
         M = database,
         F = get_result,
@@ -24,6 +25,7 @@ The entry timer resets to the TTL every time an item is read.  You need to dirty
 the result of M:F(Key) will change from what is in the cache.
 
 Use a cache:
+
         Result = pcache:get(my_cache, <<"bob">>).
         pcache:dirty(my_cache, <<"bob">>, <<"newvalue">>).  % replace entry for <<"bob">>
         pcache:dirty(my_cache, <<"bob">>).  % remove entry from cache
@@ -32,13 +34,15 @@ Use a cache:
         RandomKeys = pcache:rand_keys(my_cache, 12).
 
 Bonus feature: use arbitrary M:F/1 calls in a cache:
+
         Result = pcache:memoize(my_cache, OtherMod, OtherFun, Arg).
         pcache:dirty_memoize(my_cache, OtherMod, OtherFun, Arg).  % remove entry from cache
 
-pcache:memoize/4 helps us get around annoying issues of one-cache-per-mod-fun.
-Your root cache Mod:Fun could be nonsense if you want to use pcache:memoize/4 everywhere.
+`pcache:memoize/4` helps us get around annoying issues of one-cache-per-mod-fun.
+Your root cache Mod:Fun could be nonsense if you want to use `pcache:memoize/4` everywhere.
 
 Short-hand to make a supervisor entry:
+
        SupervisorWorkerTuple = pcache:cache_sup(Name, M, F, Size).
 
 Status

--- a/src/pcache_server.erl
+++ b/src/pcache_server.erl
@@ -115,10 +115,6 @@ handle_call({get, Key}, _From, #cache{datum_index = DatumIndex, cache_used = Use
   {reply, Reply, State#cache{cache_used = New_Size}};
 
 handle_call(total_size, _From, #cache{datum_index = _DatumIndex, cache_used = Used} = State) ->
-  %%AllProcs = ets:tab2list(DatumIndex),
-  %%Pids = [Pid || {_DatumId, Pid} <- AllProcs],
-  %%Size = lists:map(fun(X) -> {ok, S} = get_mem(X), S end, Pids),
-  %%{reply, lists:sum(Size), State};
   {reply, Used, State};
 
 handle_call(stats, _From, #cache{datum_index = DatumIndex} = State) ->
@@ -251,15 +247,6 @@ key(M, F, A) -> {M, F, A}.
 %% ===================================================================
 %% Private
 %% ===================================================================
-
-get_mem(DatumPid) ->
-  DatumPid ! {memsize, self()},
-  receive
-    {memsize, DatumPid, {memory, Size}} -> {ok, Size}
-  after
-    100 -> {no_size, timeout}
-  end.
-
 get_data(DatumPid) ->
   DatumPid ! {get, self()},
   receive

--- a/src/pcache_server.erl
+++ b/src/pcache_server.erl
@@ -10,7 +10,7 @@
 
 -record(cache, {name, datum_index, data_module, 
                 reaper_pid, data_accessor, cache_size,
-                cache_policy, default_ttl}).
+                cache_policy, default_ttl, cache_used = 0}).
 
 % make 8 MB cache
 start_link(Name, Mod, Fun) ->
@@ -46,7 +46,8 @@ init([Name, Mod, Fun, CacheSize, CacheTime, CachePolicy]) ->
                  reaper_pid = ReaperPid,
                  default_ttl = CacheTime,
                  cache_policy = CachePolicy,
-                 cache_size = CacheSizeBytes},
+                 cache_size = CacheSizeBytes,
+                 cache_used = 0},
   {ok, State}.
 
 locate(DatumKey, #cache{datum_index = DatumIndex, data_module = DataModule,
@@ -54,7 +55,7 @@ locate(DatumKey, #cache{datum_index = DatumIndex, data_module = DataModule,
                   data_accessor = DataAccessor} = _State) ->
   Key = key(DatumKey),
   case ets:lookup(DatumIndex, Key) of 
-    [{Key, Pid}] -> {found, Pid};
+    [{Key, Pid, _}] -> {found, Pid};
     []           -> Pid = launch_datum(DatumKey, DatumIndex, DataModule,
                                        DataAccessor, DefaultTTL, Policy),
                     {launched, Pid};
@@ -65,7 +66,7 @@ locate_memoize(DatumKey, DatumIndex, DataModule,
                DataAccessor, DefaultTTL, Policy) ->
   Key = key(DataModule, DataAccessor, DatumKey),
   case ets:lookup(DatumIndex, Key) of 
-    [{Key, Pid}] -> {found, Pid};
+    [{Key, Pid, _}] -> {found, Pid};
     []           -> Pid = launch_memoize_datum(DatumKey,
                             DatumIndex, DataModule,
                             DataAccessor, DefaultTTL, Policy),
@@ -93,23 +94,32 @@ handle_call({generic_get, M, F, Key}, _From, #cache{datum_index = DatumIndex,
   end,
   {reply, Reply, State};
 
-handle_call({get, Key}, _From, #cache{datum_index = _DatumIndex} = State) ->
+handle_call({get, Key}, _From, #cache{datum_index = DatumIndex, cache_used = Used} = State) ->
 %    io:format("Requesting: (~p)~n", [Key]),
-  Reply = 
+  {Reply, New_Size} = 
   case locate(Key, State) of
-    {failed, Other} -> {failed, Other};
-      {_, DatumPid} -> case get_data(DatumPid) of
-                         {ok, Data} -> Data;
-                         {no_data, timeout} -> no_data
-                       end
+    {failed, Other} -> {{failed, Other}, State};
+    {Found_Or_Launch, DatumPid} -> 
+      Used_New = case Found_Or_Launch of
+        launched -> case ets:match_object(DatumIndex, {'_', DatumPid, '_'}) of
+                      [{_, _, Size}] -> Used + Size; 
+                      _ -> Used
+                    end;
+        _ -> Used
+      end,
+      case get_data(DatumPid) of
+        {ok, Data} -> {Data, Used_New};
+        {no_data, timeout} -> {no_data, Used_New}
+      end
   end,
-  {reply, Reply, State};
+  {reply, Reply, State#cache{cache_used = New_Size}};
 
-handle_call(total_size, _From, #cache{datum_index = DatumIndex} = State) ->
-  AllProcs = ets:tab2list(DatumIndex),
-  Pids = [Pid || {_DatumId, Pid} <- AllProcs],
-  Size = lists:map(fun(X) -> {ok, S} = get_mem(X), S end, Pids),
-  {reply, lists:sum(Size), State};
+handle_call(total_size, _From, #cache{datum_index = _DatumIndex, cache_used = Used} = State) ->
+  %%AllProcs = ets:tab2list(DatumIndex),
+  %%Pids = [Pid || {_DatumId, Pid} <- AllProcs],
+  %%Size = lists:map(fun(X) -> {ok, S} = get_mem(X), S end, Pids),
+  %%{reply, lists:sum(Size), State};
+  {reply, Used, State};
 
 handle_call(stats, _From, #cache{datum_index = DatumIndex} = State) ->
   EtsInfo = ets:info(DatumIndex),
@@ -126,7 +136,7 @@ handle_call(empty, _From, #cache{datum_index = DatumIndex} = State) ->
   {reply, ok, State};
 
 handle_call(reap_oldest, _From, #cache{datum_index = DatumIndex} = State) ->
-  GetOldest = fun({_Key, Pid}, {APid, Acc}) ->
+  GetOldest = fun({_Key, Pid, _Size}, {APid, Acc}) ->
                 Pid ! {last_active, self()},
                 receive
                   {last_active, Pid, LastActive} ->
@@ -146,7 +156,7 @@ handle_call(reap_oldest, _From, #cache{datum_index = DatumIndex} = State) ->
 
 handle_call({rand, Type, Count}, _From, 
   #cache{datum_index = DatumIndex} = State) ->
-  AllPids = case ets:match(DatumIndex, {'_', '$1'}) of
+  AllPids = case ets:match(DatumIndex, {'_', '$1', '_'}) of
               [] -> [];
               Found -> lists:flatten(Found)
             end, 
@@ -172,7 +182,7 @@ handle_call(Arbitrary, _From, State) ->
 
 handle_cast({dirty, Id, NewData}, #cache{datum_index = DatumIndex} = State) ->
   case ets:lookup(DatumIndex, Id) of
-    [{Id, Pid}] -> Pid ! {new_data, self(), NewData},
+    [{Id, Pid, _}] -> Pid ! {new_data, self(), NewData},
                    receive 
                      {new_data, Pid, _OldData} -> ok
                    after 
@@ -184,7 +194,7 @@ handle_cast({dirty, Id, NewData}, #cache{datum_index = DatumIndex} = State) ->
 
 handle_cast({dirty, Id}, #cache{datum_index = DatumIndex} = State) ->
   case ets:lookup(DatumIndex, Id) of
-    [{Id, Pid}] -> Pid ! {destroy, self()},
+    [{Id, Pid, _}] -> Pid ! {destroy, self()},
                    receive 
                      {destroy, Pid, ok} -> ok
                    after 
@@ -197,7 +207,7 @@ handle_cast({dirty, Id}, #cache{datum_index = DatumIndex} = State) ->
 handle_cast({generic_dirty, M, F, A}, 
     #cache{datum_index = DatumIndex} = State) ->
   case ets:lookup(DatumIndex, key(M, F, A)) of
-    [{{M, F, A}, Pid}] -> Pid ! {destroy, self()},
+    [{{M, F, A}, Pid, _}] -> Pid ! {destroy, self()},
                    receive 
                      {destroy, Pid, ok} -> ok
                    after 
@@ -219,9 +229,13 @@ handle_info({'DOWN', _Ref, process, ReaperPid, _Reason},
   {noreply, State#cache{reaper_pid = NewReaperPid}};
 
 handle_info({'DOWN', _Ref, process, Pid, _Reason}, 
-    #cache{datum_index = DatumIndex} = State) ->
-  ets:match_delete(DatumIndex, {'_', Pid}),
-  {noreply, State};
+    #cache{datum_index = DatumIndex, cache_used=Used} = State) ->
+  New_State = case ets:match_object(DatumIndex, {'_', Pid, '_'}) of
+    [{Key, _, Size}] -> ets:delete(DatumIndex, Key),
+                        State#cache{cache_used = Used - Size};
+    _ -> State 
+  end,
+  {noreply, New_State};
 
 handle_info(Info, State) ->
   io:format("Other info of: ~p~n", [Info]),
@@ -274,7 +288,8 @@ launch_datum(Key, EtsIndex, Module, Accessor, TTL, CachePolicy) ->
   UseKey = key(Key),
   Datum = create_datum(UseKey, CacheData, TTL, CachePolicy),
   {Pid, _Monitor} = erlang:spawn_monitor(?MODULE, datum_loop, [Datum]),
-  ets:insert(EtsIndex, {UseKey, Pid}),
+  {_, Size} = process_info(Pid, memory),
+  ets:insert(EtsIndex, {UseKey, Pid, Size}),
   Pid.
 
 launch_memoize_datum(Key, EtsIndex, Module, Accessor, TTL, CachePolicy) ->
@@ -282,7 +297,8 @@ launch_memoize_datum(Key, EtsIndex, Module, Accessor, TTL, CachePolicy) ->
   UseKey = key(Module, Accessor, Key),
   Datum = create_datum(UseKey, CacheData, TTL, CachePolicy),
   {Pid, _Monitor} = erlang:spawn_monitor(?MODULE, datum_loop, [Datum]),
-  ets:insert(EtsIndex, {UseKey, Pid}),
+  {_, Size} = process_info(Pid, memory),
+  ets:insert(EtsIndex, {UseKey, Pid, Size}),
   Pid.
 
 update_ttl(#datum{started = Started, ttl = TTL,
@@ -342,7 +358,7 @@ datum_loop(#datum{key = Key, mgr = Mgr, last_active = LastActive,
 
     {destroy, From} ->
       From ! {destroy, self(), ok},
-% io:format("destroying ~p with last access of ~p~n", [self(), LastActive]),
+      % io:format("destroying ~p with last access of ~p~n", [self(), LastActive]),
       exit(self(), destroy);
 
     {InvalidRequest, From} ->

--- a/src/pcache_server.erl
+++ b/src/pcache_server.erl
@@ -252,7 +252,7 @@ get_data(DatumPid) ->
   receive
     {get, DatumPid, Data} -> {ok, Data}
   after
-    100 -> {no_data, timeout}
+    5000 -> {no_data, timeout}
   end.
 
 get_key(DatumPid) ->

--- a/src/pcache_server.erl
+++ b/src/pcache_server.erl
@@ -142,7 +142,7 @@ handle_call(reap_oldest, _From, #cache{datum_index = DatumIndex} = State) ->
     false -> no_datum;
     _ -> OldPid ! {destroy, self()}
   end,
-  {from, ok, State};
+  {reply, ok, State};
 
 handle_call({rand, Type, Count}, _From, 
   #cache{datum_index = DatumIndex} = State) ->


### PR DESCRIPTION
Frequent scan of memsize keeps all record processes alive(no entry got expired) - thus cache keep growing.
create a state to track cache usage, thus no need to do scan.
